### PR TITLE
Create reporting_servicenow.yaml.epp

### DIFF
--- a/templates/reporting_servicenow.yaml.epp
+++ b/templates/reporting_servicenow.yaml.epp
@@ -1,0 +1,7 @@
+---
+api_url: <%= $reporting_servicenow::url%>
+console_url: <%= $reporting_servicenow::puppet_console %>
+debug: <%= $reporting_servicenow::debug %>
+# add servicenow username and password below
+username: PROVIDE_THE_SERVICENOW_USER
+password: PROVIDE_THE_PASSWORD


### PR DESCRIPTION
Existing template file is named reporting_servicenow.epp while the manifest/init.pp is looking for reporting_servicenow.yaml.epp