### PR TITLE
Fix typos

### DIFF
--- a/lib/puppet/reports/reporting_servicenow.rb
+++ b/lib/puppet/reports/reporting_servicenow.rb
@@ -59,7 +59,7 @@ Puppet::Reports.register_report(:reporting_servicenow) do
         u_risk_resources: '2',
         u_risk_backout: '3',
         u_risk_complex: '1',
-        work_notes: "Node Reports: [code]<a class='web' target='_blank' href='#{PUPPETCONSOLE}/#/node_groups/inventory/node/#{host}/reports'>Reports</a>[/code]\n#{line}",
+        work_notes: "Node Reports: [code]<a class='web' target='_blank' href='#{PUPPETCONSOLE}/#/inventory/node/#{host}/reports'>Reports</a>[/code]\n#{line}",
       }
 
       debug("payload:\n#{request_body_map}\n-----\n")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 # @param debug optional flag to activate debugging messages 
 
 class reporting_servicenow (
-  Stdlib::Httpsurl $url = 'https://instance.service-now.com/api/now/table/change_request?sysparm_fields=',
+  Stdlib::Httpsurl $url = 'https://instance.service-now.com/api/now/table/incident',
   Stdlib::Httpsurl $puppet_console = 'https://puppet.example.com',
   Boolean $debug = false
 ) {
@@ -33,7 +33,7 @@ class reporting_servicenow (
     group   => 'pe-puppet',
     mode    => '0644',
     replace => false,
-    content => epp("${module_name}/${module_name}.yaml.epp"),
+    content => epp("${module_name}/${module_name}.epp"),
   }
 
   # Needed to compile rest-client


### PR DESCRIPTION
Line 8: Fix default value for `$url`
Line 36: Fix `epp("${module_name}/${module_name}.yaml.epp")` to `epp("${module_name}/${module_name}.epp")`
Line 62: Fix report URI to match PE 2019.8.1+ location