### PR TITLE
Added incident auto close

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ On the Puppet Master, this module:
 reporting_servicenow requires the rest-client gem.  This will be installed as part of the class, along
 with the supporting libraries and compilers need to build it.
 
-
 ### Beginning with reporting_servicenow
 
 There are 4 steps to the reporting_servicenow configuration:
@@ -39,11 +38,13 @@ There are 4 steps to the reporting_servicenow configuration:
 
 ```puppet
 class { 'reporting_servicenow':
-  username       => 'your user',
-  password       => 'eyaml encrypted password',
-  url            => 'https://<YOUR SERVICENOW INSTANCE HERE>/api/now/table/incident',
-  puppet_console => 'https://<YOUR CONSOLE HERE>',
-  caller_id      => '7816f79cc0a8017511c5a33be04be441',
+  username               => 'your user',
+  password               => 'eyaml encrypted password',
+  url                    => 'https://<YOUR SERVICENOW INSTANCE HERE>/api/now/table/incident',
+  puppet_console         => 'https://<YOUR CONSOLE HERE>',
+  caller_id              => '7816f79cc0a8017511c5a33be04be441',
+  auto_resolve_incidents => true
+  incident_state         => 6
 }
 ```
 
@@ -57,6 +58,8 @@ debug: false
 category: 'software'
 subcategory: 'Operating System'
 caller_id: '7816f79cc0a8017511c5a33be04be441'
+auto_resolve_incidents: true
+incident_state: 6
 # add servicenow username and password below
 username: 'your user'
 password: 'Eyaml decrypted password'
@@ -74,6 +77,8 @@ debug: false
 category: 'software'
 subcategory: 'Operating System'
 caller_id: '7816f79cc0a8017511c5a33be04be441'
+auto_resolve_incidents: true
+incident_state: 6
 # add servicenow username and password below
 username: 'your user'
 password: 'Eyaml decrypted password'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,37 +5,57 @@
 
 **Classes**
 
-* [`reporting_servicenow`](#reporting_servicenow): 
+* [`reporting_servicenow`](#reporting_servicenow): Create incidents in ServiceNOW to document corrective changes
 
 ## Classes
 
 ### reporting_servicenow
 
-The reporting_servicenow class.
+A corrective change will result in an incident in ServiceNOW. The incident will be prefilled with
+the data below. If configured, the incident can be closed automatically.
+
+#### Examples
+
+##### 
+
+```puppet
+class { 'reporting_servicenow':
+  username              => 'admin',
+  password              => 'EYaml encrypted very secret password',
+  url                   => 'https://<YOUR SERVICENOW INSTANCE HERE>/api/now/table/incident',
+  puppet_console        => 'https://<YOUR CONSOLE HERE>',
+  debug                 => false,
+  category              => 'my category',
+  subcategory           => 'my subcategory',
+  assignment_group      => 'Service Desk',
+  auto_resolve_incident => true,
+  incident_state        => 6,
+}
+```
 
 #### Parameters
 
 The following parameters are available in the `reporting_servicenow` class.
 
-##### `password`
-
-Data type: `Sensitive[String]`
-
-
-
 ##### `username`
 
 Data type: `String`
 
-
+ServieNow username, must be able to open incidents, defaults to 'admin'
 
 Default value: 'admin'
+
+##### `password`
+
+Data type: `Sensitive[String]`
+
+ServiceNow password for the above user, needs to be eyaml encrypted
 
 ##### `url`
 
 Data type: `Stdlib::Httpsurl`
 
-
+SewrviceNow URL for API integration
 
 Default value: 'https://instance.service-now.com/api/now/table/incident'
 
@@ -43,7 +63,7 @@ Default value: 'https://instance.service-now.com/api/now/table/incident'
 
 Data type: `Stdlib::Httpsurl`
 
-
+URL of the Puppet Console
 
 Default value: 'https://puppet.example.com'
 
@@ -51,7 +71,7 @@ Default value: 'https://puppet.example.com'
 
 Data type: `Boolean`
 
-
+optional flag to activate debugging messages
 
 Default value: `false`
 
@@ -59,7 +79,7 @@ Default value: `false`
 
 Data type: `String`
 
-
+ServiceNow incident category, defaults to 'software'
 
 Default value: 'software'
 
@@ -67,7 +87,7 @@ Default value: 'software'
 
 Data type: `String`
 
-
+ServiceNow incident subcategory, defaults to 'Operating System'
 
 Default value: 'Operating System'
 
@@ -75,7 +95,7 @@ Default value: 'Operating System'
 
 Data type: `String`
 
-
+ServiceNow user sys_id for the user to be inserted as caller
 
 Default value: ''
 
@@ -83,7 +103,7 @@ Default value: ''
 
 Data type: `String`
 
-
+ServiceNow incident assignment group, defaults to 'Service Desk'
 
 Default value: 'Service Desk'
 
@@ -91,7 +111,9 @@ Default value: 'Service Desk'
 
 Data type: `Boolean`
 
-
+Close the incident with incident_state. Puppet's corrective change fixed the configuration
+drift and the incident documents the issue. Therefore the incident can be resolved or closed
+automatically.
 
 Default value: `false`
 
@@ -99,7 +121,7 @@ Default value: `false`
 
 Data type: `Integer`
 
-
+ServiceNow state for incident close
 
 Default value: 6
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,6 +30,7 @@ class { 'reporting_servicenow':
   assignment_group      => 'Service Desk',
   auto_resolve_incident => true,
   incident_state        => 6,
+  pe_reporting_url_part => '/#/enforcement/node'
 }
 ```
 
@@ -124,4 +125,12 @@ Data type: `Integer`
 ServiceNow state for incident close
 
 Default value: 6
+
+##### `pe_reporting_url_part`
+
+Data type: `String`
+
+PE reoprting url part
+
+Default value: '/#/enforcement/node'
 

--- a/lib/puppet/reports/reporting_servicenow.rb
+++ b/lib/puppet/reports/reporting_servicenow.rb
@@ -22,6 +22,7 @@ Puppet::Reports.register_report(:reporting_servicenow) do
   ASSIGNMENTGROUP = @config['assignment_group']
   AUTORESOLVEINCIDENT = @config['auto_resolve_incidents']
   SN_INCIDENTSTATE = @config['incident_state']
+  PE_REPORTING_URL_PART = @config['pe_reporting_url_part']
 
   # write debug output
   def debug(msg)
@@ -93,6 +94,7 @@ Puppet::Reports.register_report(:reporting_servicenow) do
       line = line.to_s + "#{log.time} #{log.level} #{log.message}\n"
     end
 
+    reporting_url = "#{PUPPETCONSOLE}#{PE_REPORTING_URL_PART}/#{host}/reports"
     request_body_map = {
       type: 'Standard',
       short_description: "Puppet Corrective Change on #{host}",
@@ -112,7 +114,7 @@ Puppet::Reports.register_report(:reporting_servicenow) do
       u_risk_resources: '2',
       u_risk_backout: '3',
       u_risk_complex: '1',
-      work_notes: "Node Reports: [code]<a class='web' target='_blank' href='#{PUPPETCONSOLE}/#/inventory/node/#{host}/reports'>Reports</a>[/code]\n#{line}",
+      work_notes: "Node Reports: [code]<a class='web' target='_blank' href='#{reporting_url}'>Reports</a>[/code]\n#{line}",
     }
 
     debug("payload:\n#{request_body_map}\n-----\n")

--- a/lib/puppet/reports/reporting_servicenow.rb
+++ b/lib/puppet/reports/reporting_servicenow.rb
@@ -95,6 +95,7 @@ Puppet::Reports.register_report(:reporting_servicenow) do
     end
 
     reporting_url = "#{PUPPETCONSOLE}#{PE_REPORTING_URL_PART}/#{host}/reports"
+    debug("reporting url: #{reporting_url}")
     request_body_map = {
       type: 'Standard',
       short_description: "Puppet Corrective Change on #{host}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@ class reporting_servicenow (
   String $assignment_group          = 'Service Desk',
   Boolean $auto_resolve_incident    = false,
   Integer $incident_state           = 6,
-  String $pe_reporting_url_part     = '/#/enforcement/node'
+  String $pe_reporting_url_part     = '/#/inventory/node'
 ) {
   pe_ini_setting { "${module_name}_enable_reports":
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
-# @summary Send corrective changes to ServiceNOW
+# @summary 
+#    Create incidents in ServiceNOW to document corrective changes
 #
-# A crrective change will result in an incident in ServiceNOW. The incident will be prefilled with
+# A corrective change will result in an incident in ServiceNOW. The incident will be prefilled with
 # the data below. If configured, the incident can be closed automatically.
 #
 # @param username 
@@ -31,20 +32,27 @@
 #    ServiceNow incident assignment group, defaults to 'Service Desk'
 #
 # @param auto_resolve_incident
-#    Close the incident with incident_state
+#    Close the incident with incident_state. Puppet's corrective change fixed the configuration
+#    drift and the incident documents the issue. Therefore the incident can be resolved or closed
+#    automatically.
 #
 # @param incident_state
 #    ServiceNow state for incident close
 #
 # @example
 #   class { 'reporting_servicenow':
-#     username       => 'admin',
-#     password       => 'EYaml encrypted very secret password',
-#     url            => 'https://<YOUR SERVICENOW INSTANCE HERE>/api/now/table/incident',
-#     puppet_console => 'https://<YOUR CONSOLE HERE>',
+#     username              => 'admin',
+#     password              => 'EYaml encrypted very secret password',
+#     url                   => 'https://<YOUR SERVICENOW INSTANCE HERE>/api/now/table/incident',
+#     puppet_console        => 'https://<YOUR CONSOLE HERE>',
+#     debug                 => false,
+#     category              => 'my category',
+#     subcategory           => 'my subcategory',
+#     assignment_group      => 'Service Desk',
+#     auto_resolve_incident => true,
+#     incident_state        => 6,
 #   }
 #   
-
 class reporting_servicenow (
   Sensitive[String] $password,
   String $username                  = 'admin',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,9 @@
 # @param incident_state
 #    ServiceNow state for incident close
 #
+# @param pe_reporting_url_part
+#    PE reoprting url part
+#
 # @example
 #   class { 'reporting_servicenow':
 #     username              => 'admin',
@@ -51,6 +54,7 @@
 #     assignment_group      => 'Service Desk',
 #     auto_resolve_incident => true,
 #     incident_state        => 6,
+#     pe_reporting_url_part => '/#/enforcement/node'
 #   }
 #   
 class reporting_servicenow (
@@ -65,6 +69,7 @@ class reporting_servicenow (
   String $assignment_group          = 'Service Desk',
   Boolean $auto_resolve_incident    = false,
   Integer $incident_state           = 6,
+  String $pe_reporting_url_part     = '/#/enforcement/node'
 ) {
   pe_ini_setting { "${module_name}_enable_reports":
     ensure  => present,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -73,6 +73,8 @@ describe 'reporting_servicenow' do
           .with_content(%r{subcategory: Operating System})
           .with_content(%r{caller_id: 7816f79cc0a8017511c5a33be04be441})
           .with_content(%r{assignment_group: Service Desk})
+          .with_content(%r{auto_resolve_incidents: false})
+          .with_content(%r{incident_state: 6})
 
         is_expected.to contain_package('gcc')
           .with(

--- a/templates/reporting_servicenow.yaml.epp
+++ b/templates/reporting_servicenow.yaml.epp
@@ -8,6 +8,7 @@ caller_id: <%= $reporting_servicenow::caller_id %>
 assignment_group: <%= $reporting_servicenow::assignment_group %>
 auto_resolve_incidents: <%= $reporting_servicenow::auto_resolve_incident %>
 incident_state: <%= $reporting_servicenow::incident_state %>
+pe_reporting_url_part: <%= $reporting_servicenow::pe_reporting_url_part %>
 # add servicenow username and password below
 username: <%= $reporting_servicenow::username %>
 password: <%= unwrap($reporting_servicenow::password) %>


### PR DESCRIPTION
I added the parameters ‘auto_resolve_incidents’ and ‘incident_state’. With ‘auto_resolve_incidents’ set to true an incident is closed automatically with the state set in ‘incident_state’. For example if ‘incident_state’ is set to 6 the incident is resolved and ‘incident_state’ set to 7 the incident is closed.

As Puppet fixed configuration drift during a corrective change it is valid to close the incident automatically as it documents the corrective change in ServiceNow. The Puppet report documents the changes made.

I updated the unit tests and the docs.